### PR TITLE
Fix cose_sign api to have encode return the start of the sign struct

### DIFF
--- a/include/cose/sign.h
+++ b/include/cose/sign.h
@@ -127,18 +127,26 @@ int cose_sign_add_signer(cose_sign_t *sign, const cose_signer_t *signer);
 
 /**
  * cose_sign_sign signs the data from the sign object with the attached
- * signers. The output is placed in the out param, up to s_out bytes are
- * written
+ * signers. The output is placed in the supplied buffer, starting at the
+ * position indicated by the out parameter.
  *
- * @param   sign    Sign struct to encode
- * @param   buf     Buffer to write in
- * @param   len     Size of the buffer to write in
- * @param   ct      CN_CBOR context for cbor block allocation
+ * This function uses the buffer as scratch space to first calculate all the
+ * signatures. Therefor this buffer should be large enough to contain the
+ * headers, the payload, the additionally authenticated data and the
+ * signatures at the same time. This is a limitation caused by how the COSE
+ * signatures to be generated and how crypto libraries require their message
+ * as one continuous block of data.
+ *
+ * @param       sign    Sign struct to encode
+ * @param       buf     Buffer to write in
+ * @param[out]  out     Pointer to where the COSE sign struct starts
+ * @param       len     Size of the buffer to write in
+ * @param       ct      CN_CBOR context for cbor block allocation
  *
  * @return          The number of bytes written
  * @return          Negative on error
  */
-ssize_t cose_sign_encode(cose_sign_t *sign, uint8_t *buf, size_t len, cn_cbor_context *ct);
+ssize_t cose_sign_encode(cose_sign_t *sign, uint8_t *buf, size_t len, uint8_t **out, cn_cbor_context *ct);
 
 /**
  * cose_sign_decode parses a buffer to a cose sign struct. This buffer can
@@ -168,6 +176,10 @@ ssize_t cose_sign_get_kid(cose_sign_t *sign, uint8_t idx, const uint8_t **kid);
 
 /**
  * Verify the idx't signature of the signed data with the supplied signer object
+ *
+ * The buffer is required as scratch space to build the signature structs in.
+ * The buffer must be large enough to contain the headers, payload and the
+ * additional authenticated data.
  *
  * @param   sign        The sign object to verify
  * @param   signer      The signer to verify with

--- a/src/cose_encrypt.c.bck
+++ b/src/cose_encrypt.c.bck
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2018 Freie Universitat Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+int test;

--- a/src/cose_sign.c
+++ b/src/cose_sign.c
@@ -256,7 +256,7 @@ int cose_sign_generate_signature(cose_sign_t *sign, cose_signature_t *sig, uint8
 
 
 /* TODO: splitme */
-ssize_t cose_sign_encode(cose_sign_t *sign, uint8_t *buf, size_t len, cn_cbor_context *ct)
+ssize_t cose_sign_encode(cose_sign_t *sign, uint8_t *buf, size_t len, uint8_t **out, cn_cbor_context *ct)
 {
     cn_cbor_errback errp;
     /* The buffer here is used to contain dummy data a number of times */
@@ -354,6 +354,7 @@ ssize_t cose_sign_encode(cose_sign_t *sign, uint8_t *buf, size_t len, cn_cbor_co
     }
 
     /* Serialize array */
+    *out = buf;
     size_t res = cn_cbor_encoder_write(buf, 0, len, cn_top);
     cn_cbor_free(cn_top, ct);
 


### PR DESCRIPTION
Extra return pointer to indicate the start of the actual return data.