### PR TITLE
docs: remove unsupported ecdsa notes

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -28,4 +28,4 @@ list of features that are supported at the moment by this library
 - [x] Signature per signer headers
 
 - [x] EdDSA based signing and verification
-- [x] ECDSA basedi signing and verification
+- [x] ECDSA based signing and verification

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ libcose will never call malloc related calls by itself. However it does
 require a simple block array allocator for cbor management.
 
 Libcose implements modern ed25519 based signatures for signing. ECDSA based
-signing and verification might be implemented at some point. RSA will probably
+signing and verification is implemented using Mbed TLS. RSA will probably
 be skipped.
 
 ### Dependencies:


### PR DESCRIPTION
ECDSA (nist curves) are actually supported