### PR TITLE
README: Link to online documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Libcose implements modern ed25519 based signatures for signing. ECDSA based
 signing and verification is implemented using Mbed TLS. RSA will probably
 be skipped.
 
+There is [online documentation](https://bergzand.github.io/libcose/) available.
+
 ### Dependencies:
 
 - [NanoCBOR]


### PR DESCRIPTION
Adds a link to the README page so people don't have to guess that docs are probably built on github pages.

(Oddly, I didn't find whether there's an actual build script that executes this, but hey, the files there look valid, and it's also referenced from the [RIOT module](https://riot-os.org/api/group__pkg__libcose.html).)