### PR TITLE
cose/crypto: pass buffer length to aead_encrypt

### DIFF
--- a/include/cose/crypto.h
+++ b/include/cose/crypto.h
@@ -74,8 +74,18 @@ COSE_ssize_t cose_crypto_keygen(uint8_t *buf, size_t len, cose_algo_t algo);
  * @name crypto AEAD functions
  * @{
  */
-/**
- * Generic AEAD function, key must match sizes of selected algo
+ /**
+ * @brief    Generic AEAD function, key must match sizes of selected algo
+ *
+ *
+ * @param[out]      c       resulting ciphertext
+ * @param[inout]    clen    length of the buffer, length of resulting ciphertext
+ * @param           msg     message to encrypt
+ * @param           msglen  length of the message
+ * @param           aad     additional authenticated data to protect
+ * @param           aadlen  length of the additional authenticated data
+ * @param           key     key to decrypt with
+ * @param           nonce   nonce to use
  */
 int cose_crypto_aead_encrypt(uint8_t *c, size_t *clen, const uint8_t *msg, size_t msglen, const uint8_t *aad, size_t aadlen, const uint8_t *nsec, const uint8_t *npub, const uint8_t *key, cose_algo_t algo);
 int cose_crypto_aead_decrypt(uint8_t *msg,

--- a/src/cose_crypto.c
+++ b/src/cose_crypto.c
@@ -120,6 +120,9 @@ int cose_crypto_aead_decrypt(uint8_t *msg, /* NOLINT(readability-non-const-param
                              const uint8_t *k,
                              cose_algo_t algo)
 {
+    if (clen == 0) {
+        return COSE_ERR_CRYPTO;
+    }
     /* NOLINTNEXTLINE(hicpp-multiway-paths-covered) */
     switch(algo) {
 #ifdef HAVE_ALGO_CHACHA20POLY1305

--- a/src/cose_encrypt.c
+++ b/src/cose_encrypt.c
@@ -159,7 +159,7 @@ static COSE_ssize_t _encrypt_payload(cose_encrypt_t *encrypt, uint8_t *buf, size
         buf += enc_size;
         /* At this point we have our AAD at encp with length enc_size and the
          * encrypt->payload@encrypt->payload_len to feed our algo */
-        size_t cipherlen = 0;
+        size_t cipherlen = len;
         cose_crypto_aead_encrypt(buf, &cipherlen, encrypt->payload, encrypt->payload_len, encp, enc_size, NULL, nonce, encrypt->cek, algo);
         *out = buf;
         return cipherlen;


### PR DESCRIPTION
It also asserts that clen to decipher is non 0.