### PR TITLE
include/cose/crypto/selectors: fix selectors

### DIFF
--- a/include/cose/crypto/selectors.h
+++ b/include/cose/crypto/selectors.h
@@ -69,14 +69,14 @@
 #define HAVE_ALGO_AESGCM    /**< AES GCM mode support */
 #endif
 
-#if defined(HAVE_ALGO_AES128CCM_16_64_128) || \
-    defined(HAVE_ALGO_AES128CCM_64_64_128) || \
-    defined(HAVE_ALGO_AES128CCM_16_128_128) || \
-    defined(HAVE_ALGO_AES128CCM_64_128_128) || \
-    defined(HAVE_ALGO_AES128CCM_16_64_256) || \
-    defined(HAVE_ALGO_AES128CCM_64_64_256) || \
-    defined(HAVE_ALGO_AES128CCM_16_128_256) || \
-    defined(HAVE_ALGO_AES128CCM_64_128_256)
+#if defined(HAVE_ALGO_AESCCM_16_64_128) || \
+    defined(HAVE_ALGO_AESCCM_64_64_128) || \
+    defined(HAVE_ALGO_AESCCM_16_128_128) || \
+    defined(HAVE_ALGO_AESCCM_64_128_128) || \
+    defined(HAVE_ALGO_AESCCM_16_64_256) || \
+    defined(HAVE_ALGO_AESCCM_64_64_256) || \
+    defined(HAVE_ALGO_AESCCM_16_128_256) || \
+    defined(HAVE_ALGO_AESCCM_64_128_256)
 #define HAVE_ALGO_AESCCM
 #endif
 


### PR DESCRIPTION
Seems the defines were always wrong...